### PR TITLE
Make PNG rendering optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinyvg"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 repository = "https://github.com/lily-mara/tinyvg-rs"
 description = "Rust decoder and renderer for the tinyvg image format"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,18 @@ license = "MIT"
 name = "bench"
 harness = false
 
+[features]
+default = ["render-png"]
+render-png = ["cairo-rs", "piet-cairo"]
+
 [dependencies]
 byteorder = "1.4.3"
-cairo-rs = { version = "0.14.0", features = ["png"] }
+cairo-rs = { version = "0.14.0", features = ["png"], optional = true }
 eyre = "0.6.5"
 kurbo = "0.8.3"
 packed_struct = "0.10.0"
 piet = "0.5.0"
-piet-cairo = "0.5.0"
+piet-cairo = { version = "0.5.0", optional = true }
 structopt = "0.3.25"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ fn main() -> eyre::Result<()> {
 }
 ```
 
+## Features
+
+- `render-png` (default) - enables the ability to render TinyVG images into PNG files.
+  Disabling this removes the cairo dependency. This can be useful if you're already using
+  piet with another backend.
+
 # Development
 
 ## Testing

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,9 +1,7 @@
-use cairo::{Format, ImageSurface};
 use eyre::{Context, Result};
 use kurbo::{Arc, BezPath, CubicBez, Line, QuadBez, SvgArc, Vec2};
 use piet::kurbo::{Point, Size};
 use piet::{Color, FixedLinearGradient, FixedRadialGradient, GradientStop, RenderContext};
-use piet_cairo::CairoRenderContext;
 
 use crate::format::{Command, OutlineStyle, Segment, SegmentCommand, SegmentCommandKind, Style};
 
@@ -20,7 +18,11 @@ impl crate::format::Image {
     ///
     /// image.render_png(&mut file).unwrap();
     /// ```
+    #[cfg(feature = "render-png")]
     pub fn render_png(&self, writer: &mut impl std::io::Write) -> Result<()> {
+        use cairo::{Format, ImageSurface};
+        use piet_cairo::CairoRenderContext;
+
         let size = Size {
             width: self.header.width as f64,
             height: self.header.height as f64,

--- a/src/render_helper.rs
+++ b/src/render_helper.rs
@@ -18,6 +18,7 @@ use eyre::{Context, Result};
 ///   Some("data/shield-render.png".into())
 /// ).unwrap();
 /// ```
+#[cfg(feature = "render-png")]
 pub fn render(in_path: impl AsRef<Path>, out_path: Option<PathBuf>) -> Result<()> {
     let mut decoder = Decoder::new(BufReader::new(File::open(&in_path)?));
 


### PR DESCRIPTION
This PR makes the `cairo-rs` and `piet-cairo` dependencies optional, gated behind a feature `render-png` which is enabled by default (AFAICT it must be because of main.rs's dependency on it, correct me if I'm wrong. Backwards compatibility is a nice bonus.)

I needed this feature because I'd like to use this library in [fizzerb](https://github.com/liquidev/fizzerb), but fizzerb already uses the platform-specific Piet renderer via Druid, so it doesn't make sense to pull in Cairo for each platform.