### PR TITLE
Make tinyvg binary require render-png feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ license = "MIT"
 name = "bench"
 harness = false
 
+[[bin]]
+name = "tinyvg"
+path = "src/main.rs"
+required-features=["render-png"]
+
 [features]
 default = ["render-png"]
 render-png = ["cairo-rs", "piet-cairo"]


### PR DESCRIPTION
If you build this crate with `--no-default-features` currently the build errors, unless you also supply the `--lib` param, to avoid building the binary.

This just adds a section for the binary which was previously implied, adding to that the  `render-png` to the `required-features`.
so that `--no-default-features` build works without having to pass `--lib`.

